### PR TITLE
update to version numbers before tagging release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>psidev.psi.mi</groupId>
     <artifactId>psimi-master</artifactId>
     <packaging>pom</packaging>
-    <version>1.8.6-SNAPSHOT</version>
+    <version>1.8.7</version>
 
     <name>PSI</name>
     <description>Base build file</description>
@@ -38,11 +38,11 @@
         <psimi.version>${pom.version}</psimi.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jami.version>1.0.1-SNAPSHOT</jami.version>
+        <jami.version>1.0.2</jami.version>
         <jami.commons.version>1.1.3-SNAPSHOT</jami.commons.version>
         <jami.core.version>1.2.2-SNAPSHOT</jami.core.version>
         <jami.xml.version>1.1.3-SNAPSHOT</jami.xml.version>
-        <jami.mitab.version>1.1.2-SNAPSHOT</jami.mitab.version>
+        <jami.mitab.version>1.1.3</jami.mitab.version>
         <jami.batch.version>1.1.1-SNAPSHOT</jami.batch.version>
         <jami.bridges.version>1.1.2-SNAPSHOT</jami.bridges.version>
         <jami.crosslink.version>1.1.1-SNAPSHOT</jami.crosslink.version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,14 @@
             <timezone>0</timezone>
         </developer>
 
+        <developer>
+            <id>arnaudceol</id>
+            <name>Arnaud Ceol</name>
+            <email></email>
+            <organization>Center for Genomic Science, Istituto Italiano di Tecnologia (IIT)</organization>
+            <timezone>0</timezone>
+        </developer>
+
     </developers>
 
     <licenses>

--- a/psi-jami/jami-mitab/pom.xml
+++ b/psi-jami/jami-mitab/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>psidev.psi.mi.jami</groupId>
         <artifactId>psi-jami</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>jami-mitab</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3</version>
     <name>PSI :: JAMI - MITAB</name>
     <description>JAMI - MITAB parser and writer</description>
 

--- a/psi-jami/pom.xml
+++ b/psi-jami/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>psidev.psi.mi</groupId>
     <artifactId>psimi-master</artifactId>
-    <version>1.8.6-SNAPSHOT</version>
+    <version>1.8.7</version>
   </parent>
 
   <groupId>psidev.psi.mi.jami</groupId>
   <artifactId>psi-jami</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.0.2</version>
     <packaging>pom</packaging>
   <name>PSI :: JAMI - Java framework for molecular interactions</name>
   <description>JAMI master module</description>


### PR DESCRIPTION
This pull request updates the version numbers in the project prior to tagging a release.

We may want to check out #12 before actually tagging.

Also adds @arnaudceol  to developer list in top level pom.xml